### PR TITLE
fix(contact form): adjust label and placeholder

### DIFF
--- a/public/templates/form.html
+++ b/public/templates/form.html
@@ -22,12 +22,12 @@
                     required>
         </div>
         <div class="form-group">
-            <label for="footerFormLocation" class="control-label">Where are you from?</label>
+            <label for="footerFormLocation" class="control-label">What's your address?</label>
             <input class="form-control"
                     type="text"
                     name="location"
                     id="footerFormLocation"
-                    placeholder="City, State"
+                    placeholder="123 Some St, Eau Claire, WI 54701"
                     required>
         </div>
         <div class="form-group">


### PR DESCRIPTION
Use address instead of location, to prompt full address entry